### PR TITLE
Bug - Handling error if there is a theme without icons

### DIFF
--- a/src/app/components/icon-list/icon-list.component.ts
+++ b/src/app/components/icon-list/icon-list.component.ts
@@ -19,6 +19,7 @@ export class IconListComponent implements OnInit, OnDestroy {
     this.subscribeStore = this.ps.theme.subscribe((item: Theme) => {
       // When data is fetched from outside Angular scope, Zone will let angular know about it
       this.zone.run(() => {
+        if(!item) return;
         this.icons = item.icons;
       });
     });


### PR DESCRIPTION
**Describe pull-request**  
_Describe what the pull-request is about_
If there is no icons it has to have some kind of fallback not causing error when not using scania-theme icons.

![image](https://user-images.githubusercontent.com/35451568/93251221-34b94900-f794-11ea-9cc2-ab7bec1472ba.png)

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: scania/corporate-ui#583

**How to test**  
_Add description how to test if possible_
Go to digitaldesign and change theme, no error should be shown now,

