### PR TITLE
Fix tab nav scrolling on mobile view

### DIFF
--- a/src/app/components/page/styles/tab-nav.scss
+++ b/src/app/components/page/styles/tab-nav.scss
@@ -4,6 +4,8 @@
     position: sticky;      
     top: 64px;
     z-index: 999;
+    overflow-x: auto;
+    white-space: nowrap;
 
     #page-tabs {
       margin:0;


### PR DESCRIPTION
Fix #154

**Describe pull-request**  
On mobile, tab nav should not have a line break, horisontal scrolling is provided for long menu tab.


**How to test**  
Check on smaller screen, on page  /foundation/foundation-typography that has long menu tab

**Screenshots**  
_If applicable, add screenshots to help explain_
![image](https://user-images.githubusercontent.com/1199101/102335930-d2d5ce80-3f90-11eb-9fa6-eb394e2826b4.png)

